### PR TITLE
import_base.py:

### DIFF
--- a/scripts/import_base.py
+++ b/scripts/import_base.py
@@ -10,10 +10,15 @@ class RVDImport:
     def __init__(self):
         # Authentication for user filing issue (must have read/write access to
         # repository to add issue to)
-        self.token = os.environ['GITHUB_TOKEN'] #ffb0d091869e647e3db4baa4d71dcb5c3c6a17d7
+        try:
+            self.token = os.environ['GITHUB_TOKEN'] #ffb0d091869e647e3db4baa4d71dcb5c3c6a17d7
+        except KeyError:
+            print("Make sure that you've GITHUB_TOKEN exported")
+            exit(1)
         # First create a Github instance:
         # or using an access token
         self.g = Github(self.token)
+
 
     # def __init__(self, user, password):
     #     # TODO


### PR DESCRIPTION
* Graceful exit when GITHUB_TOKEN is not set

Before:

Traceback (most recent call last):
  File "import_asan.py", line 224, in <module>
    importer = RVDImport_ASan(username="aliasrobotics", repo="RVD")
  File "import_asan.py", line 14, in __init__
    super().__init__()
  File "/tmp/RVD/scripts/import_base.py", line 13, in __init__
    self.token = os.environ['GITHUB_TOKEN'] #ffb0d091869e647e3db4baa4d71dcb5c3c6a17d7
  File "/usr/lib/python3.5/os.py", line 725, in __getitem__
    raise KeyError(key) from None
KeyError: 'GITHUB_TOKEN'

After:

Make sure that you've GITHUB_TOKEN exported

Signed-off-by: LanderU <lander.usategui@gmail.com>