### PR TITLE
Low down the severity for running os commands

### DIFF
--- a/rvd_tools/cli.py
+++ b/rvd_tools/cli.py
@@ -26,10 +26,11 @@ from .importer.gitlab import *
 from .cve.cve import *
 from .statistics.statistics import *
 from .reports.reports import *
+from subprocess import call as run_cmd
+import shlex
 import sys
 import json
 import os
-import subprocess
 #import pprint
 from datetime import datetime
 import arrow
@@ -898,7 +899,8 @@ def exportar_local(update):
     else:
         if update:
             cyan("Updating all tickets, re-downloading...")
-            os.system("rm -r " + local_directory_path)
+            cmd = f"rm -r {local_directory_path}"
+            run_cmd(shlex.split(cmd))
             os.makedirs(".rvd")
             flag_fetch = True
         else:
@@ -959,7 +961,8 @@ def fetch():
     #     sys.exit(1)
     # else:
     cyan("Creating the default folder for the import process...")
-    os.system("mkdir -p /tmp/rvd")
+    cmd = "mkdir -p /tmp/rvd"
+    run_cmd(shlex.split(cmd))
 
 
 @fetch.command("local")

--- a/rvd_tools/database/duplicates.py
+++ b/rvd_tools/database/duplicates.py
@@ -10,7 +10,9 @@ Class that manages de-duplication of RVD flaws
 import dedupe
 from .base import *
 from ..utils import gray, red, green, cyan, yellow
+from subprocess import call as run_cmd
 import sys
+import shlex
 import os
 import yaml
 from .flaw import *
@@ -107,7 +109,8 @@ class Duplicates(Base):
         else:
             if update:
                 cyan("Updating all tickets, re-downloading...")
-                os.system("rm -r " + local_directory_path)
+                cmd = f"rm -r {local_directory_path}"
+                run_cmd(shlex.split(cmd))
                 os.makedirs(".rvd")
             else:
                 yellow("Directory already exists, skipping")

--- a/rvd_tools/reports/reports.py
+++ b/rvd_tools/reports/reports.py
@@ -10,7 +10,9 @@ Class to generate PDF reports from tickets, both private or public
 from ..utils import cyan
 import os
 from ..importer.gitlab import *
+from subprocess import call as run_cmd
 import arrow
+import shlex
 
 
 class Report:
@@ -24,9 +26,10 @@ class Report:
         """
         Generate a report from a Gitlab private archive
         """
-        cyan("Creating temporary directory /tmp/rvd/reports/" + str(id) + " ...")
-        temp_dir = "/tmp/rvd/reports/" + str(id)
-        os.system("mkdir -p " + temp_dir)
+        cyan(f"Creating temporary directory /tmp/rvd/reports/{id} ...")
+        temp_dir = f"/tmp/rvd/reports/{id}"
+        cmd = f"mkdir -p {temp_dir}"
+        run_cmd(shlex.split(cmd))
 
         # Create the markdown file
         cyan("Creating Markdown file...")


### PR DESCRIPTION
Before this patch:

```bash
	Total issues (by severity):
		Undefined: 0.0
		Low: 13.0
		Medium: 0.0
		High: 4.0
```

After:

```bash
	Total issues (by severity):
		Undefined: 0.0
		Low: 17.0
		Medium: 0.0
		High: 1.0
```

I've tried to completely remove the issues, even low ones, but, I think you need to add exceptions for these type of calls.

The remaining `High` issue is in the following piece of code: 

* https://github.com/aliasrobotics/RVD/blob/master/rvd_tools/cve/cve.py#L153-L168

I'll let Alias Robotics developers to decide how to proceed here.

Signed-off-by: LanderU <lander.usategui@gmail.com>